### PR TITLE
refactor: 优化心跳超时处理，避免长时间异常时持续重试

### DIFF
--- a/src/udp.rs
+++ b/src/udp.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use bytes::BytesMut;
 use chrono::Local;
 use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use pnet::datalink::MacAddr;
 
 use crate::settings::Settings;
@@ -130,7 +130,9 @@ impl<'a> Process<'a> {
                                 if cnt > count {
                                     quit.store(true, Ordering::Release);
                                 } else {
-                                    thread::sleep(duration);
+                                    let backoff = duration * (1 << min(cnt, 4));
+                                    let backoff = min(backoff, Duration::from_secs(30));
+                                    thread::sleep(backoff);
                                 }
                             }
                         }
@@ -246,7 +248,9 @@ impl<'a> Process<'a> {
                                     if cnt > count {
                                         quit.store(true, Ordering::Release);
                                     } else {
-                                        thread::sleep(duration);
+                                        let backoff = duration * (1 << min(cnt, 4));
+                                        let backoff = min(backoff, Duration::from_secs(30));
+                                        thread::sleep(backoff);
                                     }
                                 }
                             }
@@ -491,6 +495,7 @@ impl<'a> Process<'a> {
         let timeout = self.timeout.clone();
         let udp_timeout = self.settings.heartbeat.udp_timeout;
         let count = min(self.settings.retry.count, u8::MAX as i32) as u8;
+        let max_timeout_count = count.saturating_mul(3);
         self.heartbeat_handle = Some(Arc::new(thread::Builder::new().name("UDP-Heartbeat".to_owned()).spawn(move || {
             let duration = std::time::Duration::from_secs(udp_timeout as u64);
             loop {
@@ -503,12 +508,17 @@ impl<'a> Process<'a> {
                 }
                 alive.store(true, Ordering::Release);
                 thread::sleep(duration);
-                let mut cnt = timeout.load(Ordering::Relaxed);
-                if cnt > count {
-                    error!("Heartbeat timeout. No Misc Heartbeat packet received for {}s, but ignored.", udp_timeout * cnt as i32);
-                    cnt = 0;
+                let cnt = timeout.fetch_add(1, Ordering::AcqRel);
+                if cnt >= count {
+                    let total_secs = udp_timeout * (cnt as i32 + 1);
+                    if cnt >= max_timeout_count {
+                        error!("Heartbeat timeout. No Misc Heartbeat packet received for {total_secs}s, triggering reconnection.");
+                        stop.store(true, Ordering::Release);
+                        return;
+                    } else {
+                        warn!("Heartbeat timeout. No Misc Heartbeat packet received for {total_secs}s, but ignored.");
+                    }
                 }
-                timeout.store(cnt + 1, Ordering::Release);
             }
         }).expect("Can't create UDP-Heartbeat thread.")));
     }


### PR DESCRIPTION
## 背景

在网络波动或服务端长时间未返回心跳包时，当前 UDP 流程会持续按固定节奏重试。
这会带来两个问题：

1. `send` / `receive` 出错时重试间隔固定，异常期间容易反复打满重试节奏
2. 心跳超时达到阈值后仍然只是继续忽略，连接可能长期停留在异常状态，无法主动进入重连流程

## 改动

本 PR 主要调整了 `src/udp.rs` 中的超时与重试策略：

- 为 UDP 收发错误重试引入指数退避
- 给退避时间增加上限，避免等待时间无限放大
- 心跳检测改为累计超时计数
- 在前几次超时时继续告警并容忍抖动
- 当累计超时达到更高阈值后，主动触发重连而不是无限忽略

## 效果

这样处理后：

- 短时网络抖动下仍然能保持一定容错
- 长时间收不到心跳时能够更快回到可恢复状态
- 异常期间不会持续高频重试，能降低缓冲区耗尽或无效重发的风险

## 兼容性

- 未修改协议字段和报文格式
- 仅调整线程内部的重试/超时处理逻辑

## 测试

本次主要是行为层调整，已基于代码路径检查以下场景：

- UDP 收发异常时退避时间逐步增加
- 心跳恢复时 `timeout` 计数可正常清零
- 连续超时达到阈值后会触发 `stop`，进入后续重连流程
